### PR TITLE
feat: allow connecting homes to nixos

### DIFF
--- a/modules/home.nix
+++ b/modules/home.nix
@@ -2,94 +2,14 @@
 { lib, config }:
 let
   inherit (config) inputs;
-
-  
+  homes-type = import ./homes-type.nix { inherit lib config; };
 in
 {
   options.homes = lib.options.create {
-      description = "Home-Manager homes to create.";
-      default.value = { };
-      type = lib.types.attrs.of (lib.types.submodule ({ config }: let
-        homeForSystem = system: config.home-manager.lib.homeManagerConfiguration {
-          pkgs = config.pkgs.${system};
-          lib = config.pkgs.lib;
-          extraSpecialArgs = { inherit system; } // config.args;
-          modules = config.modules;
-        };
-
-        result = builtins.listToAttrs (builtins.map (system: {
-          name = system;
-          value = homeForSystem system;
-        }) config.systems);
-
-        home_name = config.__module__.args.dynamic.name;
-        home_name_parts = builtins.match "([a-z][-a-z0-9]*)(@([-A-Za-z0-9]+))?(:([-_A-Za-z0-9]+))?" home_name;
-
-        username = builtins.elemAt home_name_parts 0;
-        system = builtins.elemAt home_name_parts 4;
-
-        systemProvided = system != null;
-
-        defaultModules = [
-          ({ lib, ... }: {
-            home.username = lib.modules.mkDefault username;
-          })
-        ];
-      in {
-        options = {
-          systems = lib.options.create {
-            description = "The systems this home is valid on.";
-            type = lib.types.list.of lib.types.string;
-          } // (if systemProvided then {
-            default.value = [ system ];
-            writeable = false;
-          } else {});
-          
-          args = lib.options.create {
-            description = "Additional arguments to pass to home-manager modules.";
-            type = lib.types.attrs.any;
-            default.value = { };
-          };
-
-          home-manager = lib.options.create {
-            description = "The home-manager input to use.";
-            type = lib.types.raw;
-            default.value =
-              if inputs ? home-manager
-              then inputs.home-manager.result
-              else null;
-          };
-
-          pkgs = lib.options.create {
-            description = "The Nixpkgs instance to use.";
-            type = lib.types.raw;
-            default.value =
-              if
-                inputs ? nixpkgs
-              then
-                inputs.nixpkgs.result
-              else
-                null;
-          };
-
-          modules = lib.options.create {
-            description = "A list of modules to use for home-manager.";
-            type = lib.types.list.of lib.types.raw;
-          };
-
-          result = lib.options.create {
-            description = "The created Home Manager home for each of the systems.";
-            type = lib.types.attrs.of lib.types.raw;
-            writable = false;
-            default.value = result;
-          };
-        };
-
-        config = {
-          modules = defaultModules; # Provided down here rather than as a default so they don't get overriden when a user specifies additional modules
-        };
-      }));
-    };
+    description = "Home-Manager homes to create.";
+    default.value = { };
+    type = homes-type;
+  };
 
   config = {
     assertions = lib.attrs.mapToList

--- a/modules/homes-type.nix
+++ b/modules/homes-type.nix
@@ -1,0 +1,89 @@
+{ lib, config }:
+let
+  inherit (config) inputs;
+in lib.types.attrs.of (lib.types.submodule (
+  {
+    name = "home";
+    description = "A home-manager home";
+    module = { config }: let
+      homeForSystem = system: config.home-manager.lib.homeManagerConfiguration {
+        pkgs = config.pkgs.${system};
+        lib = config.pkgs.lib;
+        extraSpecialArgs = { inherit system; } // config.args;
+        modules = config.modules;
+      };
+
+      result = builtins.listToAttrs (builtins.map (system: {
+        name = system;
+        value = homeForSystem system;
+      }) config.systems);
+
+      home_name = config.__module__.args.dynamic.name;
+      home_name_parts = builtins.match "([a-z][-a-z0-9]*)(@([-A-Za-z0-9]+))?(:([-_A-Za-z0-9]+))?" home_name;
+
+      username = builtins.elemAt home_name_parts 0;
+      system = builtins.elemAt home_name_parts 4;
+
+      systemProvided = system != null;
+
+      defaultModules = [
+        ({ lib, ... }: {
+          home.username = lib.modules.mkDefault username;
+        })
+      ];
+    in {
+      options = {
+        systems = lib.options.create {
+          description = "The systems this home is valid on.";
+          type = lib.types.list.of lib.types.string;
+        } // (if systemProvided then {
+          default.value = [ system ];
+          writeable = false;
+        } else {});
+    
+        args = lib.options.create {
+          description = "Additional arguments to pass to home-manager modules.";
+          type = lib.types.attrs.any;
+          default.value = { };
+        };
+
+        home-manager = lib.options.create {
+          description = "The home-manager input to use.";
+          type = lib.types.raw;
+          default.value =
+            if inputs ? home-manager
+            then inputs.home-manager.result
+            else null;
+        };
+
+        pkgs = lib.options.create {
+          description = "The Nixpkgs instance to use.";
+          type = lib.types.raw;
+          default.value =
+            if
+              inputs ? nixpkgs
+            then
+              inputs.nixpkgs.result
+            else
+              null;
+        };
+
+        modules = lib.options.create {
+          description = "A list of modules to use for home-manager.";
+          type = lib.types.list.of lib.types.raw;
+        };
+
+        result = lib.options.create {
+          description = "The created Home Manager home for each of the systems.";
+          type = lib.types.attrs.of lib.types.raw;
+          writable = false;
+          default.value = result;
+        };
+      };
+
+      config = {
+        modules = defaultModules; # Provided down here rather than as a default so they don't get overriden when a user specifies additional modules
+      };
+    };
+  }
+))

--- a/modules/homes-type.nix
+++ b/modules/homes-type.nix
@@ -1,7 +1,7 @@
 { lib, config }:
 let
   inherit (config) inputs;
-in lib.types.attrs.of (lib.types.submodule (
+in lib.types.attrs.of (lib.types.submodules.portable (
   {
     name = "home";
     description = "A home-manager home";

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -1,0 +1,112 @@
+{ config, lib }@global:
+let
+  inherit (global.config) inputs;
+  homes-type = import ./homes-type.nix { inherit config lib; };
+in
+{
+  options.systems = {
+    nixos = lib.options.create {
+      type = lib.types.attrs.of (lib.types.submodule ({ config, name, ... }@submodule: {
+        options = {
+          home-manager = lib.options.create {
+            description = "The home-manager input to use.";
+            type = lib.types.raw;
+            default.value =
+              if inputs ? home-manager
+              then inputs.home-manager.result
+              else null;
+          };
+
+          homes = lib.options.create {
+            description = "Homes to activate for the system, with the same naming scheme as nilla-home's config.homes option";
+            type = homes-type;
+            default.value = {};
+          };
+        };
+
+        config.modules = let
+          system = submodule.config.pkgs.system;
+          warn' = builtins.warn or builtins.trace; # builtins.warn doesn't exist on some versions of nix/lix
+          warnIf = condition: message: value: if condition then warn' message value else value;
+          homeManager = submodule.config.home-manager;
+        in (lib.fp.pipe [
+          (lib.attrs.mapToList (homeName: home: let
+            homeNameParts = builtins.match "([a-z][-a-z0-9]*)(@([-A-Za-z0-9]+))?(:([-_A-Za-z0-9]+))?" homeName;
+            username = builtins.elemAt homeNameParts 0;
+          in {
+            inherit home homeName username;
+          }))
+          (builtins.map ({home, homeName, username}@identity:
+            warnIf (home.home-manager != homeManager)
+              "The home \"${homeName}\" isn't using the same home-manager input as the NixOS system \"${name}\". This may work, but is not officially supported by the Nilla Home or Nilla NixOS maintainers. Please fix this before reporting any bugs you may find."
+            identity))
+          (builtins.map ({home, homeName, username}: { lib, ... }: {
+            _file = "virtual:nilla-nix/home/nixos/${homeName}/nixos";
+            config.home-manager.users.${username} = { ... }: {
+              _file = "virtual:nilla-nix/home/nixos/${homeName}/homeModule";
+              imports = home.modules ++ [ {
+                config._module.args = home.args;
+                _file = "virtual:nilla-nix/home/nixos/${homeName}/args";
+              } ];
+            };
+            config.users.users.${username}.isNormalUser = lib.modules.mkDefault true;
+          }))
+          lib.lists.flatten
+        ] submodule.config.homes) ++ (
+          if submodule.config.homes != []
+          then [ submodule.config.home-manager.nixosModules.default ]
+          else []
+        );
+      }));
+    };
+  };
+
+  config = {
+    assertions = lib.lists.flatten (lib.attrs.mapToList
+      (name: value: let
+        hasNixpkgs = !(builtins.isNull value.pkgs);
+        requestedHomes = value.homes != [];
+        hasHomeManager = !(builtins.isNull value.home-manager);
+      in [
+        {
+          assertion = hasNixpkgs;
+          message = "A Nixpkgs instance is required for the NixOS system \"${name}\", but none was provided and \"inputs.nixpkgs\" does not exist.";
+        }
+        {
+          assertion = !requestedHomes || hasHomeManager;
+          message = "A home-manager instance is required to enable homes for the NixOS system \"${name}\", but none was provided and \"inputs.home-manager\" does not exist.";
+        }
+        (lib.attrs.mapToList (homeName: home: let
+          homeHasHomeManager = !(builtins.isNull home.home-manager);
+          homeIsValidForSystem = home ? result.${value.pkgs.system};
+        in [
+          {
+            assertion = homeHasHomeManager;
+            message = "You've asked for the home \"${homeName}\" to be activated in the NixOS system \"${name}\", but it needs a home-manager instance, none was provided and \"inputs.home-manager\" does not exist.";
+          }
+          {
+            assertion = !homeHasHomeManager || !hasNixpkgs || homeIsValidForSystem;
+            message = "You've asked for the home \"${homeName}\" to be activated in the NixOS system \"${name}\", but it isn't valid for \"${value.pkgs.system}\" systems.";
+          }
+        ]) value.homes)
+        (let
+          usernames = lib.attrs.mapToList (homeName: home: let
+            homeHasHomeManager = !(builtins.isNull home.home-manager);
+            homeIsValidForSystem = home ? result.${value.pkgs.system};
+          in 
+            if homeHasHomeManager && hasNixpkgs && homeIsValidForSystem
+            then let
+              homeNameParts = builtins.match "([a-z][-a-z0-9]*)(@([-A-Za-z0-9]+))?(:([-_A-Za-z0-9]+))?" homeName;
+              username = builtins.elemAt homeNameParts 0;
+            in username
+            else null) value.homes;
+          existingUsernames = builtins.filter (username: username != null) usernames;
+          uniqueUsernames = lib.lists.unique existingUsernames;
+        in {
+          assertion = !hasNixpkgs || (existingUsernames == uniqueUsernames);
+          message = "There are multiple homes for a single user in the NixOS system \"${name}\". Please make sure you've only enabled a single home per user.";
+        })
+      ])
+      global.config.systems.nixos);
+  };
+}

--- a/nilla.nix
+++ b/nilla.nix
@@ -23,6 +23,7 @@ nilla.create ({ config }: {
 
     modules.nilla = {
       home = ./modules/home.nix;
+      nixos = ./modules/nixos.nix;
     };
 
     packages.default = config.packages.nilla-home;

--- a/npins/default.nix
+++ b/npins/default.nix
@@ -82,7 +82,7 @@ let
     if url != null && !submodules then
       builtins.fetchTarball {
         inherit url;
-        sha256 = hash; # FIXME: check nix version & use SRI hashes
+        sha256 = hash;
       }
     else
       let
@@ -109,9 +109,9 @@ let
       in
       builtins.fetchGit {
         rev = revision;
-        inherit name;
-        # hash = hash;
-        inherit url submodules;
+        narHash = hash;
+
+        inherit name submodules url;
       };
 
   mkPyPiSource =
@@ -140,7 +140,7 @@ let
       sha256 = hash;
     };
 in
-if version == 5 then
+if version == 6 then
   builtins.mapAttrs mkSource data.pins
 else
   throw "Unsupported format version ${toString version} in sources.json. Try running `npins upgrade`"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -11,7 +11,7 @@
       "submodules": false,
       "revision": "e3be528e4f03538852ba49b413ec4ac843edeb60",
       "url": "https://github.com/nix-community/fenix/archive/e3be528e4f03538852ba49b413ec4ac843edeb60.tar.gz",
-      "hash": "1bz4qlxb2r103mhgi77g3642h442943hgyfrm2q7bpsv9dm42qjs"
+      "hash": "sha256-WmJBaktb33WwqNn5BwdJghAoiBnvnPhgHSBksTrF5K8="
     },
     "nilla": {
       "type": "GitRelease",
@@ -24,10 +24,10 @@
       "version_upper_bound": null,
       "release_prefix": null,
       "submodules": false,
-      "version": "v0.0.0-alpha.12",
-      "revision": "5d3e509727f387a3000d9ac32031836661f233c9",
-      "url": "https://api.github.com/repos/nilla-nix/nilla/tarball/v0.0.0-alpha.12",
-      "hash": "0y70c9p4ln0jd673k2ifi28s92pgphjdykgar71s20bv2qzg8naz"
+      "version": "v0.0.0-alpha.14",
+      "revision": "2e98ae315a592ad6b6de44670514c048dcc88dc7",
+      "url": "https://api.github.com/repos/nilla-nix/nilla/tarball/refs/tags/v0.0.0-alpha.14",
+      "hash": "sha256-15lwhWcMonJH6UholMMHDc+p2BoSpGA4AYGrsXQA9Do="
     },
     "nixpkgs": {
       "type": "Git",
@@ -40,8 +40,8 @@
       "submodules": false,
       "revision": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
       "url": "https://github.com/nixos/nixpkgs/archive/d89fc19e405cb2d55ce7cc114356846a0ee5e956.tar.gz",
-      "hash": "1i3sj7bapriaanmnlrr6p3khr20j1k59il12fkww78ik2xa81vyx"
+      "hash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ="
     }
   },
-  "version": 5
+  "version": 6
 }


### PR DESCRIPTION
[feat: allow connecting homes to nixos](https://github.com/nilla-nix/home/commit/447f3ff7c638a242016b41f2970bf53532701ba8)

Using this module allows you to attach homes to nilla-nix/nixos

You will be able to add the home by doing

  `systems.nixos.<name>.homes = { inherit homes.<name>; };`

which will use the home-manager nixos module to import all the home's
modules into your system!

You will need to be on at least nilla v0.0.0-alpha.14 to test this patch