### PR TITLE
fix: use global packages for NixOS attached homes

### DIFF
--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -42,6 +42,7 @@ in
             identity))
           (builtins.map ({home, homeName, username}: { lib, ... }: {
             _file = "virtual:nilla-nix/home/nixos/${homeName}/nixos";
+            config.home-manager.useGlobalPkgs = true; # Required or home modules will lose the nixpkgs config defined in nilla
             config.home-manager.users.${username} = { ... }: {
               _file = "virtual:nilla-nix/home/nixos/${homeName}/homeModule";
               imports = home.modules ++ [ {


### PR DESCRIPTION
Previously we didn't use global packages, which meant that if you had options defined in your nilla inputs for nixpkgs (to allow unfree packages, say) these would not be respected.

To fix this, we can use home-manager.useGlobalPkgs. Setting this option as a workaround was suggested to me by SqueakyBeaver - thanks!